### PR TITLE
fix keyword list

### DIFF
--- a/src/Ssh/Publickey.php
+++ b/src/Ssh/Publickey.php
@@ -39,7 +39,7 @@ class Publickey extends Subsystem
      *               associative array containing: name, blob, and attrs
      *               elements.
      */
-    public function list()
+    public function getList()
     {
         return ssh2_publickey_list($this->getResource());
     }


### PR DESCRIPTION
The public function list use a php keyword and create a php error: 
Parse error: syntax error, unexpected 'list' (T_LIST), expecting identifier (T_STRING)

I change the name of this function by getList()
