### PR TITLE
Fix unlink(); now uses the correct function

### DIFF
--- a/src/Ssh/Sftp.php
+++ b/src/Ssh/Sftp.php
@@ -121,7 +121,7 @@ class Sftp extends Subsystem
      */
     public function unlink($filename)
     {
-        return ssh2_sftp_symlink($this->getResource(), $filename);
+        return ssh2_sftp_unlink($this->getResource(), $filename);
     }
 
     /**


### PR DESCRIPTION
ssh2_sftp_unlink() is the correct function to unlink a file, not ssh2_sftp_symlink()
