### PR TITLE
Use arguments passed into connect method.

### DIFF
--- a/src/Ssh/Session.php
+++ b/src/Ssh/Session.php
@@ -137,7 +137,7 @@ class Session extends AbstractResourceHolder
      */
     protected function connect(array $arguments)
     {
-        return call_user_func_array('ssh2_connect', $this->configuration->asArguments());
+        return call_user_func_array('ssh2_connect', $arguments);
     }
 
     /**


### PR DESCRIPTION
The method wasn't use the arguments passed in.
