### PR TITLE
Added travis file for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+
+before_script:
+  - composer self-update
+  - composer install --dev


### PR DESCRIPTION
If you created a travis account you can have your unit tests run automatically, and the build status of the project displayed dynamically in the readme file.
