### PR TITLE
InvalidArgumentException could not be thrown

### DIFF
--- a/src/Ssh/Subsystem.php
+++ b/src/Ssh/Subsystem.php
@@ -22,7 +22,7 @@ abstract class Subsystem extends AbstractResourceHolder
     public function __construct($session)
     {
         if (!$session instanceof Session && !is_resource($session)) {
-            throw new InvalidArgumentException('The session must be either a Session instance or a SSH session resource.');
+            throw new \InvalidArgumentException('The session must be either a Session instance or a SSH session resource.');
         }
 
         $this->session = $session;


### PR DESCRIPTION
PHP Fatal error:  Class 'Ssh\InvalidArgumentException' not found in /Users/gabriel/Workspace/Sojeans/symfony/vendor/php-ssh/src/Ssh/Subsystem.php on line 25
