### PR TITLE
Creating a symlink failed because the wrong parameter was passed

### DIFF
--- a/src/Ssh/Sftp.php
+++ b/src/Ssh/Sftp.php
@@ -109,7 +109,7 @@ class Sftp extends Subsystem
      */
     public function symlink($target, $link)
     {
-        return ssh2_sftp_symlink($this->getResource(), $symlink, $link);
+        return ssh2_sftp_symlink($this->getResource(), $target, $link);
     }
 
     /**


### PR DESCRIPTION
Pretty straightforward pull request, just a wrong parameter name.
