### PR TITLE
Check if the URL is a directory before attempting to scan it

### DIFF
--- a/src/Ssh/Sftp.php
+++ b/src/Ssh/Sftp.php
@@ -251,9 +251,7 @@ class Sftp extends Subsystem
      * Scans a directory
      *
      * Unfortunately, using a (recursive) directory iterator is not possible
-     * over SFTP: see https://bugs.php.net/bug.php?id=57378. Also, is_dir() is
-     * unreliable and often returns false for valid directories. Therefore, I
-     * use @scandir() instead.
+     * over SFTP: see https://bugs.php.net/bug.php?id=57378.
      *
      * @param  string  $directory
      * @param  Boolean $recursive
@@ -262,7 +260,8 @@ class Sftp extends Subsystem
      */
     private function scanDirectory($directory, $recursive)
     {
-        if (!$results = @scandir($this->getUrl($directory))) {
+        $url = $this->getUrl($directory);
+        if ( ! is_dir($url) || ! $results = scandir($url)) {
             return false;
         }
 


### PR DESCRIPTION
I got alot of scandir errors on files. So I changed the code a little to check if it's a directory before attempting to scan it.

Also, I just noticed your PHPDoc comment about is_dir() being unreliable. Is this still the case and if so, how can this be reproduced?
