### PR TITLE
[BUGFIX] Added support for .ssh/config files indented with tabs or spaces

### DIFF
--- a/src/Ssh/SshConfigFileConfiguration.php
+++ b/src/Ssh/SshConfigFileConfiguration.php
@@ -60,7 +60,8 @@ class SshConfigFileConfiguration extends Configuration
         $configs = array();
         $lineNumber = 1;
         foreach (explode(PHP_EOL, $contents) as $line) {
-            if (trim($line) == '' || $line[0] == '#') {
+            $line = trim($line);
+            if ($line == '' || $line[0] == '#') {
                 continue;
             }
             $pos = strpos($line, '=');

--- a/tests/Ssh/Fixtures/config_valid
+++ b/tests/Ssh/Fixtures/config_valid
@@ -5,7 +5,7 @@ Port 1234
 #This is a comment which won't appear in the parsed array
 
 Host test
-HostName test.com
+    HostName test.com
 
 Host testuser.com
 User test


### PR DESCRIPTION
I had some problem with config file parsing. If the config file is indented with tabs (in my case) it does not detect the hostname parameter etc.
