### PR TITLE
Rely on last command exit status to raise error

### DIFF
--- a/src/Ssh/Exec.php
+++ b/src/Ssh/Exec.php
@@ -9,6 +9,7 @@ use RuntimeException;
  *
  * @author Cam Spiers <camspiers@gmail.com>
  * @author Greg Militello <junk@thinkof.net>
+ * @author Gildas Quéméner <gildas.quemener@gmail.com>
  */
 class Exec extends Subsystem
 {
@@ -19,14 +20,18 @@ class Exec extends Subsystem
 
     public function run($cmd, $pty = null, array $env = array(), $width = 80, $height = 25, $width_height_type = SSH2_TERM_UNIT_CHARS)
     {
+        $cmd .= ';echo -ne "[return_code:$?]"';
         $stdout = ssh2_exec($this->getResource(), $cmd, $pty, $env, $width, $height, $width_height_type);
         $stderr = ssh2_fetch_stream($stdout, SSH2_STREAM_STDERR);
         stream_set_blocking($stderr, true);
         stream_set_blocking($stdout, true);
-        $error = stream_get_contents($stderr);
-        if ($error !== '') {
-            throw new RuntimeException($error);
+
+        $output = stream_get_contents($stdout);
+        preg_match('/\[return_code:(.*?)\]/', $output, $match);
+        if ((int) $match[1] !== 0) {
+            throw new RuntimeException(stream_get_contents($stderr), (int) $match[1]);
         }
-        return stream_get_contents($stdout);
+
+        return preg_replace('/\[return_code:(.*?)\]/', '', $output);
     }
 }

--- a/tests/Ssh/FunctionalTests/ExecTest.php
+++ b/tests/Ssh/FunctionalTests/ExecTest.php
@@ -45,7 +45,7 @@ class ExecTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RuntimeException MessageOnStdErr
+     * @expectedException \RuntimeException
      */
     public function testExecuteErrorOutput()
     {
@@ -54,7 +54,7 @@ class ExecTest extends \PHPUnit_Framework_TestCase
         $session = new Session($configuration, $authentication);
 
         $exec = $session->getExec();
-        $output = $exec->run('echo "MessageOnStdErr" > /dev/stderr');
+        $output = $exec->run('false');
 
         $this->assertEquals('', trim($output));
     }


### PR DESCRIPTION
Some tools like composer write human-related non-error messages to
stderr, thus it's not safe to rely on stderr to decide if the command
failed.

More info:
  - https://github.com/composer/composer/issues/3795#issuecomment-76401013
  - https://github.com/composer/composer/issues/1905#issuecomment-41631659
  - https://github.com/composer/composer/pull/3715#issuecomment-73271923

Inspiration:
  - http://stackoverflow.com/questions/10478491/php-ssh2-exec-channel-exit-status
  - http://stackoverflow.com/questions/18278023/php-net-ssh2-exec-how-to-get-the-command-return-code