### PR TITLE
29 scan directory recursive fix

### DIFF
--- a/src/Ssh/Sftp.php
+++ b/src/Ssh/Sftp.php
@@ -288,7 +288,7 @@ class Sftp extends Subsystem
 
                 if ($recursive) {
                     $children    = $this->scanDirectory($filename, $recursive);
-                    if ($children !== false) {
+                    if (is_array($children)) {
                         $files       = array_merge($files, $children[0]);
                         $directories = array_merge($directories, $children[1]);
                     }

--- a/src/Ssh/Sftp.php
+++ b/src/Ssh/Sftp.php
@@ -288,8 +288,10 @@ class Sftp extends Subsystem
 
                 if ($recursive) {
                     $children    = $this->scanDirectory($filename, $recursive);
-                    $files       = array_merge($files, $children[0]);
-                    $directories = array_merge($directories, $children[1]);
+                    if ($children !== false) {
+                        $files       = array_merge($files, $children[0]);
+                        $directories = array_merge($directories, $children[1]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
We have to check the case when the function returns false if directory is empty.
Otherwise error will be thrown: "array_merge(): Argument #2 is not an array"