### PR TITLE
Fixing #53

### DIFF
--- a/src/Ssh/Authentication/PublicKeyFile.php
+++ b/src/Ssh/Authentication/PublicKeyFile.php
@@ -37,7 +37,8 @@ class PublicKeyFile implements Authentication
      */
     public function authenticate($session)
     {
-        return ssh2_auth_pubkey_file(
+        // It may throw n exception AND a warning, see https://github.com/Herzult/php-ssh/issues/53
+        return @ssh2_auth_pubkey_file(
             $session,
             $this->username,
             $this->publicKeyFile,


### PR DESCRIPTION
Silencing warning when also having an exception when using ssh2_auth_pubkey_file() on PublicKeyFile::authenticate