### PR TITLE
Add last output to Exec

### DIFF
--- a/src/Ssh/Exec.php
+++ b/src/Ssh/Exec.php
@@ -29,7 +29,7 @@ class Exec extends Subsystem
         $output = stream_get_contents($stdout);
         preg_match('/\[return_code:(.*?)\]/', $output, $match);
         if ((int) $match[1] !== 0) {
-            throw new RuntimeException(stream_get_contents($stderr), (int) $match[1]);
+            throw new RuntimeException(stream_get_contents($stderr) . "\nLast output: " . $output, (int) $match[1]);
         }
 
         return preg_replace('/\[return_code:(.*?)\]/', '', $output);


### PR DESCRIPTION
I have currently the problem, that the connection doesn't use forwardAgent for the connection from staging to bitbucket, which is hard to debug. If I would just get the last output which says "No permission" I would have saved an hour.
