### PR TITLE
Fix SFTP getUrl function for PHP >= 5.6.28

### DIFF
--- a/src/Ssh/Sftp.php
+++ b/src/Ssh/Sftp.php
@@ -202,7 +202,7 @@ class Sftp extends Subsystem
      */
     public function getUrl($filename)
     {
-        return sprintf('ssh2.sftp://%s/%s', $this->getResource(), $filename);
+        return sprintf('ssh2.sftp://%d/%s', $this->getResource(), $filename);
     }
 
     /**


### PR DESCRIPTION
PHP 5.6.28 made an (apparently undocumented) change for scanning an SFTP directory. Previously the URL was created by casting the Resource as a string ("Resource #27"), now it requires it to be cast as an int ("27"). 

Previously this function returned ssh2.sftp://Resource #27/my/url, now returns ssh2.sftp://27/my/url.

The "new" method has been tested in 5.6.26 and still works correctly (as well as 5.6.29 and 7.0.14).