### PR TITLE
Run intval on SFTP resource.

### DIFF
--- a/src/Ssh/Sftp.php
+++ b/src/Ssh/Sftp.php
@@ -202,7 +202,7 @@ class Sftp extends Subsystem
      */
     public function getUrl($filename)
     {
-        return sprintf('ssh2.sftp://%s/%s', $this->getResource(), $filename);
+        return sprintf('ssh2.sftp://%s/%s', intval($this->getResource()), $filename);
     }
 
     /**


### PR DESCRIPTION
As of 5.6.28, it is necessary to execute `intval` on the SFTP Resource when parsing the URL.
See: http://paul-m-jones.com/archives/6439

Note: I have not tested this on PHP < 5.6.28, but I have tested and confirmed fixed for PHP 7.1.3.