### PR TITLE
cast ssh resource into int to be compliant with php >=7.0

### DIFF
--- a/src/Ssh/Sftp.php
+++ b/src/Ssh/Sftp.php
@@ -202,7 +202,7 @@ class Sftp extends Subsystem
      */
     public function getUrl($filename)
     {
-        return sprintf('ssh2.sftp://%s/%s', $this->getResource(), $filename);
+        return sprintf('ssh2.sftp://%s/%s', (int) $this->getResource(), $filename);
     }
 
     /**


### PR DESCRIPTION
With php >=7.0, I have the following error when I try to create a directory to a sftp server:
```
The directory 'my_dir' does not exist and could not be created. at /my_project/vendor/knplabs/gaufrette/src/Gaufrette/Adapter/Sftp.php:209)"}
```

The gaufrette adapter fails because of the Ssh\Sftp:getUrl() method returning an url like `ssh2.sftp://Resource id #324/my_dir`, which is incompatible in php >=7.0.

The following bug describe my issue: https://bugs.php.net/bug.php?id=73561

It is solvable by casting the resource into int before inject it in the url. 